### PR TITLE
Bundle onnxruntime-web into dist outputs

### DIFF
--- a/src/backend.js
+++ b/src/backend.js
@@ -47,11 +47,11 @@ export async function initOrt({ backend = 'webgpu', wasmPaths, numThreads } = {}
     throw new Error('ONNX Runtime Web loaded but env is not available. This might be a bundling issue.');
   }
   
-  // Set up WASM paths first (needed for all backends)
-  if (!ort.env.wasm.wasmPaths) {
-    // Use the same version as in package.json
-    const ver = '1.22.0-dev.20250409-89f8206ba4';
-    ort.env.wasm.wasmPaths = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ver}/dist/`;
+  // Set up WASM paths if explicitly provided. The bundled ONNX Runtime already
+  // includes the WASM assets so we only override when a custom path is
+  // supplied (for example when self-hosting the binaries).
+  if (wasmPaths) {
+    ort.env.wasm.wasmPaths = wasmPaths;
   }
 
   // Configure WASM for better performance

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -11,5 +11,5 @@ export default defineConfig({
   minify: false,
   platform: 'browser',
   globalName: 'Parakeet',
-  external: ['onnxruntime-web'],
+  noExternal: ['onnxruntime-web'],
 });


### PR DESCRIPTION
## Summary
- bundle the onnxruntime-web dependency directly into the library build
- defer WASM path overrides unless a custom location is provided so the bundled assets are used by default

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8d0e9b9a4832dbbe2df5c1124fb3e