### PR TITLE
Update continuous build workflow triggers

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -2,11 +2,21 @@ name: Continuous Build
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
+  workflow_dispatch:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || github.event.action != 'closed' || github.event.pull_request.merged == true
     name: Build library
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
- trigger the continuous build workflow on pull requests targeting main, merge events, and manual dispatches
- ensure the build job only runs on merged pull requests when the PR was actually merged

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ca4e54c9b4832dbb5789d5dc133d62