### PR TITLE
Restore workflow triggers for PRs and main

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -11,12 +11,12 @@ on:
       - opened
       - synchronize
       - reopened
-      - closed
+      - ready_for_review
+  merge_group:
   workflow_dispatch:
 
 jobs:
   build:
-    if: github.event_name != 'pull_request' || github.event.action != 'closed' || github.event.pull_request.merged == true
     name: Build library
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
- ensure the continuous build workflow runs for ready-for-review pull requests and merge queue executions
- remove the job-level guard so pushes to main always trigger the build

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cb332820cc832dacd2520799d042d8