### PR TITLE
Add wasm transcription tests for audiosave dataset

### DIFF
--- a/test/audiosave-transcription.test.js
+++ b/test/audiosave-transcription.test.js
@@ -1,0 +1,179 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import './helpers/setup-node-env.js';
+
+import { getParakeetModel } from '../src/hub.js';
+import { ParakeetModel } from '../src/parakeet.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const projectRoot = path.resolve(__dirname, '..');
+const audioDir = path.join(projectRoot, 'audiosave');
+
+function isNetworkError(err) {
+  if (!err) return false;
+  if (err.code === 'ENETUNREACH' || err.code === 'EAI_AGAIN') return true;
+  if (err.cause && isNetworkError(err.cause)) return true;
+  if (typeof err.errors === 'object' && err.errors) {
+    for (const nested of err.errors) {
+      if (isNetworkError(nested)) return true;
+    }
+  }
+  const msg = err.message ? String(err.message) : '';
+  return msg.includes('ENETUNREACH') || msg.includes('fetch failed');
+}
+
+async function loadWavFloat32(filePath) {
+  const buffer = await fs.readFile(filePath);
+  if (buffer.length < 44) {
+    throw new Error('Invalid WAV file – too short');
+  }
+
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  const riff = String.fromCharCode(view.getUint8(0), view.getUint8(1), view.getUint8(2), view.getUint8(3));
+  if (riff !== 'RIFF') {
+    throw new Error('Invalid WAV file – missing RIFF header');
+  }
+  const wave = String.fromCharCode(view.getUint8(8), view.getUint8(9), view.getUint8(10), view.getUint8(11));
+  if (wave !== 'WAVE') {
+    throw new Error('Invalid WAV file – missing WAVE signature');
+  }
+
+  let offset = 12;
+  let fmtChunkFound = false;
+  let audioFormat = 0;
+  let numChannels = 0;
+  let sampleRate = 0;
+  let bitsPerSample = 0;
+  let dataOffset = -1;
+  let dataSize = 0;
+
+  while (offset + 8 <= buffer.length) {
+    const chunkId = String.fromCharCode(
+      view.getUint8(offset),
+      view.getUint8(offset + 1),
+      view.getUint8(offset + 2),
+      view.getUint8(offset + 3)
+    );
+    const chunkSize = view.getUint32(offset + 4, true);
+    offset += 8;
+
+    if (chunkId === 'fmt ') {
+      fmtChunkFound = true;
+      audioFormat = view.getUint16(offset, true);
+      numChannels = view.getUint16(offset + 2, true);
+      sampleRate = view.getUint32(offset + 4, true);
+      bitsPerSample = view.getUint16(offset + 14, true);
+    } else if (chunkId === 'data') {
+      dataOffset = offset;
+      dataSize = chunkSize;
+      break;
+    }
+
+    offset += chunkSize;
+  }
+
+  if (!fmtChunkFound || dataOffset < 0) {
+    throw new Error('Invalid WAV file – missing fmt/data chunks');
+  }
+
+  if (audioFormat !== 1) {
+    throw new Error(`Unsupported WAV audio format ${audioFormat}; expected PCM`);
+  }
+
+  if (bitsPerSample !== 16) {
+    throw new Error(`Unsupported WAV bit depth ${bitsPerSample}; expected 16-bit PCM`);
+  }
+
+  if (numChannels !== 1) {
+    throw new Error(`Unsupported WAV channel count ${numChannels}; expected mono`);
+  }
+
+  if (sampleRate !== 16000) {
+    throw new Error(`Unexpected sample rate ${sampleRate}; expected 16000 Hz`);
+  }
+
+  const pcmData = buffer.subarray(dataOffset, dataOffset + dataSize);
+  const samples = new Int16Array(pcmData.buffer, pcmData.byteOffset, pcmData.byteLength / 2);
+  const floatData = new Float32Array(samples.length);
+  for (let i = 0; i < samples.length; i++) {
+    floatData[i] = samples[i] / 32768;
+  }
+  return floatData;
+}
+
+let modelPromise;
+
+async function getModel() {
+  if (!modelPromise) {
+    const wasmDir = path.resolve(projectRoot, 'node_modules/onnxruntime-web/dist');
+    const wasmDirUrl = pathToFileURL(wasmDir).href;
+    const wasmUrl = wasmDirUrl.endsWith('/') ? wasmDirUrl : `${wasmDirUrl}/`;
+
+    const hubConfig = await getParakeetModel('jarrelscy/parakeet-tdt-0.6b-v2-onnx', {
+      backend: 'wasm',
+      encoderQuant: 'int8',
+      decoderQuant: 'int8',
+    });
+
+    modelPromise = ParakeetModel.fromUrls({
+      ...hubConfig.urls,
+      filenames: hubConfig.filenames,
+      backend: 'wasm',
+      wasmPaths: wasmUrl,
+      decoderQuant: 'int8',
+      encoderQuant: 'int8',
+    });
+  }
+  return modelPromise;
+}
+
+async function collectAudioPairs() {
+  const files = await fs.readdir(audioDir);
+  const wavFiles = files.filter((f) => f.endsWith('.wav')).sort();
+  const pairs = [];
+  for (const wavFile of wavFiles) {
+    const base = wavFile.replace(/\.wav$/, '');
+    const txtFile = `${base}.txt`;
+    const txtPath = path.join(audioDir, txtFile);
+    try {
+      const expected = await fs.readFile(txtPath, 'utf8');
+      pairs.push({
+        name: base,
+        wavPath: path.join(audioDir, wavFile),
+        expected: expected.trim(),
+      });
+    } catch (err) {
+      throw new Error(`Missing transcript file for ${wavFile}: ${err.message}`);
+    }
+  }
+  return pairs;
+}
+
+test('parakeet wasm transcription matches reference texts', { timeout: 600_000 }, async (t) => {
+  let model;
+  try {
+    model = await getModel();
+  } catch (err) {
+    if (isNetworkError(err)) {
+      t.skip('Network unavailable for HuggingFace model download');
+      return;
+    }
+    throw err;
+  }
+
+  const pairs = await collectAudioPairs();
+
+  for (const pair of pairs) {
+    await t.test(`transcribes ${pair.name}`, async () => {
+      const audio = await loadWavFloat32(pair.wavPath);
+      const result = await model.transcribe(audio, 16000, { returnTimestamps: false, returnConfidences: false });
+      assert.equal(result.utterance_text.trim(), pair.expected);
+    });
+  }
+});

--- a/test/helpers/setup-node-env.js
+++ b/test/helpers/setup-node-env.js
@@ -1,0 +1,111 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+const globalScope = globalThis;
+
+if (!globalScope.self) {
+  globalScope.self = globalScope;
+}
+
+if (!globalScope.window) {
+  globalScope.window = globalScope;
+}
+
+if (!globalScope.navigator) {
+  globalScope.navigator = {};
+}
+
+if (globalScope.navigator.hardwareConcurrency === undefined) {
+  globalScope.navigator.hardwareConcurrency = 4;
+}
+
+if (globalScope.navigator.userAgent === undefined) {
+  globalScope.navigator.userAgent = 'node';
+}
+
+if (globalScope.navigator.language === undefined) {
+  globalScope.navigator.language = 'en-US';
+}
+
+if (!globalScope.location) {
+  globalScope.location = new URL('https://localhost/');
+}
+
+// Force single-threaded WASM to avoid worker requirements in Node tests.
+if (typeof globalScope.SharedArrayBuffer !== 'undefined') {
+  try {
+    Object.defineProperty(globalScope, 'SharedArrayBuffer', {
+      value: undefined,
+      configurable: true,
+    });
+  } catch {
+    globalScope.SharedArrayBuffer = undefined;
+  }
+}
+
+if (!globalScope.Blob) {
+  throw new Error('Global Blob constructor not available');
+}
+
+const blobStore = new Map();
+let blobSeq = 0;
+
+const originalCreateObjectURL = URL.createObjectURL?.bind(URL);
+const originalRevokeObjectURL = URL.revokeObjectURL?.bind(URL);
+
+URL.createObjectURL = (blob) => {
+  if (originalCreateObjectURL) {
+    try {
+      return originalCreateObjectURL(blob);
+    } catch (err) {
+      // Fall through to custom implementation
+    }
+  }
+  const id = `blob:parakeet-test-${++blobSeq}`;
+  blobStore.set(id, blob);
+  return id;
+};
+
+URL.revokeObjectURL = (url) => {
+  if (blobStore.delete(url)) {
+    return;
+  }
+  if (originalRevokeObjectURL) {
+    originalRevokeObjectURL(url);
+  }
+};
+
+const originalFetch = globalScope.fetch.bind(globalScope);
+
+function isRequestLike(obj) {
+  return typeof obj === 'object' && obj !== null && typeof obj.url === 'string';
+}
+
+globalScope.fetch = async function patchedFetch(resource, init) {
+  let url = null;
+  if (typeof resource === 'string') {
+    url = resource;
+  } else if (isRequestLike(resource)) {
+    url = resource.url;
+  }
+
+  if (typeof url === 'string') {
+    if (url.startsWith('blob:parakeet-test-')) {
+      const blob = blobStore.get(url);
+      if (!blob) {
+        throw new Error(`No blob found for URL ${url}`);
+      }
+      return new Response(blob.stream(), {
+        headers: { 'content-type': blob.type || 'application/octet-stream' },
+      });
+    }
+
+    if (url.startsWith('file://')) {
+      const path = fileURLToPath(url);
+      const data = await readFile(path);
+      return new Response(data);
+    }
+  }
+
+  return originalFetch(resource, init);
+};


### PR DESCRIPTION
## Summary
- add a Node test that loads the jarrelscy/parakeet-tdt-0.6b-v2-onnx model with the WASM backend and validates the audiosave transcripts
- introduce a minimal Node test environment polyfill so onnxruntime-web can resolve blob and file URLs during the test run

## Testing
- node --test test/audiosave-transcription.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1fe0eef54832d9bd57c932f4f0fe5