### PR TITLE
Use fp32 decoder for audiosave regression

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -3,10 +3,10 @@ name: Continuous Build
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
     types:
       - opened
       - synchronize
@@ -32,6 +32,18 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Install uv
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install --user uv
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+
+      - name: Refresh audiosave transcripts
+        run: uv run --with numpy --with onnxruntime --with huggingface-hub --with onnx-asr python scripts/generate_audiosave_transcripts.py
+
+      - name: Run tests
+        run: npm test
 
       - name: Build distributable bundles
         run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules
 dist
+.venv
+hf-cache/
 .env
 .env.local
 .env.development.local
@@ -7,4 +9,3 @@ dist
 .env.production.local
 *.pem
 docs/
-scripts/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,13 @@
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
-        "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4"
+        "onnxruntime-web": "^1.23.0"
       },
       "devDependencies": {
         "rimraf": "^6.0.1",
         "tsup": "^8.5.0",
-        "typescript": "^5.9.2"
+        "typescript": "^5.9.2",
+        "undici": "^7.16.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1438,21 +1439,21 @@
       }
     },
     "node_modules/onnxruntime-common": {
-      "version": "1.22.0-dev.20250409-89f8206ba4",
-      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz",
-      "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.23.0.tgz",
+      "integrity": "sha512-Auz8S9D7vpF8ok7fzTobvD1XdQDftRf/S7pHmjeCr3Xdymi4z1C7zx4vnT6nnUjbpelZdGwda0BmWHCCTMKUTg==",
       "license": "MIT"
     },
     "node_modules/onnxruntime-web": {
-      "version": "1.22.0-dev.20250409-89f8206ba4",
-      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz",
-      "integrity": "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.23.0.tgz",
+      "integrity": "sha512-w0bvC2RwDxphOUFF8jFGZ/dYw+duaX20jM6V4BIZJPCfK4QuCpB/pVREV+hjYbT3x4hyfa2ZbTaWx4e1Vot0fQ==",
       "license": "MIT",
       "dependencies": {
         "flatbuffers": "^25.1.24",
         "guid-typescript": "^1.0.9",
         "long": "^5.2.3",
-        "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4",
+        "onnxruntime-common": "1.23.0",
         "platform": "^1.3.6",
         "protobufjs": "^7.2.4"
       }
@@ -2109,6 +2110,16 @@
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.8.0",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
   "scripts": {
     "build": "tsup",
     "clean": "rimraf dist",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test": "node --test"
   },
   "dependencies": {
-    "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4"
+    "onnxruntime-web": "^1.23.0"
   },
   "author": "Yunus Seyhan Dede",
   "license": "MIT",
@@ -46,6 +47,7 @@
   "devDependencies": {
     "rimraf": "^6.0.1",
     "tsup": "^8.5.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "undici": "^7.16.0"
   }
 }

--- a/scripts/generate_audiosave_transcripts.py
+++ b/scripts/generate_audiosave_transcripts.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Regenerate audiosave transcripts with the onnx_asr reference decoder."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import tempfile
+import wave
+from pathlib import Path
+
+import numpy as np
+
+try:
+    import onnx_asr
+except ModuleNotFoundError as exc:  # pragma: no cover - handled in CI setup
+    missing = exc.name or "onnx_asr"
+    raise SystemExit(f"{missing} must be installed to refresh transcripts") from exc
+
+try:
+    from huggingface_hub import snapshot_download
+except ModuleNotFoundError as exc:  # pragma: no cover - handled in CI setup
+    missing = exc.name or "huggingface_hub"
+    raise SystemExit(f"{missing} must be installed to refresh transcripts") from exc
+
+
+def load_audio(path: Path) -> np.ndarray:
+    with wave.open(str(path), "rb") as wav:
+        if wav.getnchannels() != 1:
+            raise RuntimeError(f"{path} must be mono")
+        if wav.getframerate() != 16000:
+            raise RuntimeError(f"{path} must be 16000Hz")
+        if wav.getsampwidth() != 2:
+            raise RuntimeError(f"{path} must be 16-bit PCM")
+        frames = wav.readframes(wav.getnframes())
+    samples = np.frombuffer(frames, dtype="<i2").astype("float32") / 32768.0
+    return samples
+
+
+def _stage_model_directory(model_dir: str | None) -> tuple[tempfile.TemporaryDirectory[str], Path]:
+    if model_dir:
+        source = Path(model_dir)
+        if not source.exists():
+            raise SystemExit(f"Model directory {source} does not exist")
+    else:
+        source_path = snapshot_download(
+            "jarrelscy/parakeet-tdt-0.6b-v2-onnx",
+            allow_patterns=[
+                "config.json",
+                "encoder-model.onnx",
+                "encoder-model.onnx.data",
+                "decoder_joint-model.onnx",
+                "vocab.txt",
+                "nemo128.onnx",
+            ],
+        )
+        source = Path(source_path)
+
+    temp_dir = tempfile.TemporaryDirectory()
+    staged = Path(temp_dir.name)
+
+    def copy_if_exists(name: str, *, rename: str | None = None) -> Path | None:
+        src = source / name
+        if not src.exists():
+            return None
+        dest = staged / (rename or name)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+        return dest
+
+    # Always copy encoder weights (only fp32 is available today).
+    encoder_path = copy_if_exists("encoder-model.onnx")
+    if encoder_path is None:
+        raise SystemExit(f"Missing encoder-model.onnx in {source}")
+
+    copy_if_exists("encoder-model.onnx.data")
+
+    # Use the fp32 decoder to match the JavaScript configuration.
+    decoder_copied = copy_if_exists("decoder_joint-model.onnx")
+    if decoder_copied is None:
+        raise SystemExit(f"Missing decoder weights in {source}")
+
+    if copy_if_exists("vocab.txt") is None:
+        raise SystemExit(f"Missing vocab.txt in {source}")
+
+    copy_if_exists("nemo128.onnx")
+    copy_if_exists("config.json")
+
+    return temp_dir, staged
+
+
+def regenerate_transcripts(audio_dir: Path, model_dir: str | None) -> None:
+    temp_dir, staged_dir = _stage_model_directory(model_dir)
+    try:
+        model = onnx_asr.load_model("nemo-parakeet-tdt-0.6b-v2", str(staged_dir))
+
+        wav_files = sorted(p for p in audio_dir.iterdir() if p.suffix == ".wav")
+        if not wav_files:
+            raise SystemExit(f"No .wav files found in {audio_dir}")
+
+        for wav_path in wav_files:
+            samples = load_audio(wav_path)
+            text = model.recognize(samples, sample_rate=16000)
+            out_path = wav_path.with_suffix(".txt")
+            out_path.write_text(text, encoding="utf-8")
+            print(f"{wav_path.name}:\n{text}\n")
+    finally:
+        temp_dir.cleanup()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--audio-dir",
+        default=Path(__file__).resolve().parents[1] / "audiosave",
+        type=Path,
+        help="Directory containing .wav files to transcribe",
+    )
+    parser.add_argument(
+        "--model-dir",
+        default=os.environ.get("PARAKEET_LOCAL_MODEL_DIR"),
+        help="Optional directory with cached Parakeet ONNX weights",
+    )
+    args = parser.parse_args(argv)
+
+    audio_dir = args.audio_dir
+    if not audio_dir.exists():
+        raise SystemExit(f"Audio directory {audio_dir} does not exist")
+
+    regenerate_transcripts(audio_dir, args.model_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/backend.js
+++ b/src/backend.js
@@ -10,90 +10,57 @@
  * @param {string} [opts.wasmPaths] Optional path prefix for WASM binaries.
  * @returns {Promise<typeof import('onnxruntime-web').default>}
  */
+let selectedBackend = null;
+
+export function getSelectedBackend() {
+  return selectedBackend;
+}
+
 export async function initOrt({ backend = 'webgpu', wasmPaths, numThreads } = {}) {
-  // Dynamic import to handle Vite bundling issues
-  let ort;
-  
+  let ortModule;
   try {
-    const ortModule = await import('onnxruntime-web');
-    ort = ortModule.default || ortModule;
-    
-    // Debug: Check the structure of ort
-    console.log('[Parakeet.js] ORT structure:', { 
-      hasDefault: !!ortModule.default, 
-      hasEnv: !!ort.env, 
-      hasWasm: !!ort.env?.wasm,
-      hasWebgpu: !!ort.env?.webgpu,
-      keys: Object.keys(ort).slice(0, 10) // Show first 10 keys
-    });
-    
-    // If still no env, try accessing it differently
-    if (!ort.env) {
-      console.log('[Parakeet.js] Trying alternative access patterns...');
-      console.log('[Parakeet.js] ortModule keys:', Object.keys(ortModule));
-      
-      // Sometimes the module structure is nested
-      if (ortModule.ort) {
-        ort = ortModule.ort;
-        console.log('[Parakeet.js] Found ort in ortModule.ort');
-      }
-    }
-  } catch (e) {
-    console.error('[Parakeet.js] Failed to import onnxruntime-web:', e);
+    ortModule = await import('onnxruntime-web');
+  } catch (error) {
     throw new Error('Failed to load ONNX Runtime Web. Please check your network connection.');
   }
-  
+
+  let ort = ortModule.default || ortModule;
+  if (!ort.env && ortModule.ort) {
+    ort = ortModule.ort;
+  }
+
   if (!ort || !ort.env) {
     throw new Error('ONNX Runtime Web loaded but env is not available. This might be a bundling issue.');
   }
-  
-  // Set up WASM paths if explicitly provided. The bundled ONNX Runtime already
-  // includes the WASM assets so we only override when a custom path is
-  // supplied (for example when self-hosting the binaries).
+
   if (wasmPaths) {
     ort.env.wasm.wasmPaths = wasmPaths;
   }
 
-  // Configure WASM for better performance
+  const hasNavigator = typeof navigator !== 'undefined';
+  const nav = hasNavigator ? navigator : undefined;
+  const threadCount = typeof numThreads === 'number' && numThreads > 0
+    ? numThreads
+    : nav?.hardwareConcurrency || 4;
+
   if (backend === 'wasm' || backend === 'webgpu') {
-    // Enable multi-threading if supported
     if (typeof SharedArrayBuffer !== 'undefined') {
-      ort.env.wasm.numThreads = numThreads || navigator.hardwareConcurrency || 4;
+      ort.env.wasm.numThreads = threadCount;
       ort.env.wasm.simd = true;
-      console.log(`[Parakeet.js] WASM configured with ${ort.env.wasm.numThreads} threads, SIMD enabled`);
     } else {
-      console.warn('[Parakeet.js] SharedArrayBuffer not available - using single-threaded WASM');
-      ort.env.wasm.numThreads = 1;
+      ort.env.wasm.numThreads = Math.max(1, threadCount | 0);
     }
-    
-    // Enable other WASM optimizations
-    ort.env.wasm.proxy = false; // Direct execution for better performance
+
+    ort.env.wasm.proxy = false;
   }
 
   if (backend === 'webgpu') {
-    // Check WebGPU support properly
-    const webgpuSupported = 'gpu' in navigator;
-    console.log(`[Parakeet.js] WebGPU supported: ${webgpuSupported}`);
-    
-    if (webgpuSupported) {
-      try {
-        // In newer versions of ONNX Runtime Web, WebGPU initialization is automatic
-        // No need to call ort.env.webgpu.init() manually
-        console.log('[Parakeet.js] WebGPU will be initialized automatically when creating session');
-      } catch (error) {
-        console.warn('[Parakeet.js] WebGPU initialization failed:', error);
-        console.warn('[Parakeet.js] Falling back to WASM');
-        backend = 'wasm';
-      }
-    } else {
-      console.warn('[Parakeet.js] WebGPU not supported – falling back to WASM');
+    const webgpuSupported = hasNavigator && 'gpu' in navigator;
+    if (!webgpuSupported) {
       backend = 'wasm';
     }
   }
 
-  // Store the final backend choice for use in model selection
-  ort._selectedBackend = backend;
-
-  // Return the ort module for use in creating sessions and tensors
+  selectedBackend = backend;
   return ort;
 }

--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -38,17 +38,18 @@ export class ParakeetTokenizer {
    * @returns {string}
    */
   decode(ids) {
-    let text = '';
+    const pieces = [];
     for (const id of ids) {
       const token = this.id2token[id];
-      if (token === undefined) continue;
-      if (token === this.blankToken) continue;
-      if (token.startsWith('▁')) {
-        text += ' ' + token.slice(1);
-      } else {
-        text += token;
-      }
+      if (token === undefined || token === this.blankToken) continue;
+      pieces.push(token.replace(/\u2581/g, ' '));
     }
-    return text.trim();
+
+    const raw = pieces.join('');
+    if (!raw) return '';
+
+    // Mirror the spacing cleanup implemented in onnx_asr so our outputs
+    // match the Python reference decoder byte-for-byte.
+    return raw.replace(/(^\s|\s\B|(\s)\b)/g, (_, _discard, keep) => (keep ? ' ' : ''));
   }
-} 
+}

--- a/test/audiosave-transcription.test.js
+++ b/test/audiosave-transcription.test.js
@@ -1,0 +1,232 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import './helpers/setup-node-env.js';
+
+import { getParakeetModel } from '../src/hub.js';
+import { ParakeetModel } from '../src/parakeet.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const projectRoot = path.resolve(__dirname, '..');
+const audioDir = path.join(projectRoot, 'audiosave');
+
+function isNetworkError(err) {
+  if (!err) return false;
+  if (err.code === 'ENETUNREACH' || err.code === 'EAI_AGAIN') return true;
+  if (err.cause && isNetworkError(err.cause)) return true;
+  if (typeof err.errors === 'object' && err.errors) {
+    for (const nested of err.errors) {
+      if (isNetworkError(nested)) return true;
+    }
+  }
+  const msg = err.message ? String(err.message) : '';
+  return msg.includes('ENETUNREACH') || msg.includes('fetch failed');
+}
+
+async function loadWavFloat32(filePath) {
+  const buffer = await fs.readFile(filePath);
+  if (buffer.length < 44) {
+    throw new Error('Invalid WAV file – too short');
+  }
+
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  const riff = String.fromCharCode(view.getUint8(0), view.getUint8(1), view.getUint8(2), view.getUint8(3));
+  if (riff !== 'RIFF') {
+    throw new Error('Invalid WAV file – missing RIFF header');
+  }
+  const wave = String.fromCharCode(view.getUint8(8), view.getUint8(9), view.getUint8(10), view.getUint8(11));
+  if (wave !== 'WAVE') {
+    throw new Error('Invalid WAV file – missing WAVE signature');
+  }
+
+  let offset = 12;
+  let fmtChunkFound = false;
+  let audioFormat = 0;
+  let numChannels = 0;
+  let sampleRate = 0;
+  let bitsPerSample = 0;
+  let dataOffset = -1;
+  let dataSize = 0;
+
+  while (offset + 8 <= buffer.length) {
+    const chunkId = String.fromCharCode(
+      view.getUint8(offset),
+      view.getUint8(offset + 1),
+      view.getUint8(offset + 2),
+      view.getUint8(offset + 3)
+    );
+    const chunkSize = view.getUint32(offset + 4, true);
+    offset += 8;
+
+    if (chunkId === 'fmt ') {
+      fmtChunkFound = true;
+      audioFormat = view.getUint16(offset, true);
+      numChannels = view.getUint16(offset + 2, true);
+      sampleRate = view.getUint32(offset + 4, true);
+      bitsPerSample = view.getUint16(offset + 14, true);
+    } else if (chunkId === 'data') {
+      dataOffset = offset;
+      dataSize = chunkSize;
+      break;
+    }
+
+    offset += chunkSize;
+  }
+
+  if (!fmtChunkFound || dataOffset < 0) {
+    throw new Error('Invalid WAV file – missing fmt/data chunks');
+  }
+
+  if (audioFormat !== 1) {
+    throw new Error(`Unsupported WAV audio format ${audioFormat}; expected PCM`);
+  }
+
+  if (bitsPerSample !== 16) {
+    throw new Error(`Unsupported WAV bit depth ${bitsPerSample}; expected 16-bit PCM`);
+  }
+
+  if (numChannels !== 1) {
+    throw new Error(`Unsupported WAV channel count ${numChannels}; expected mono`);
+  }
+
+  if (sampleRate !== 16000) {
+    throw new Error(`Unexpected sample rate ${sampleRate}; expected 16000 Hz`);
+  }
+
+  const pcmData = buffer.subarray(dataOffset, dataOffset + dataSize);
+  const samples = new Int16Array(pcmData.buffer, pcmData.byteOffset, pcmData.byteLength / 2);
+  const floatData = new Float32Array(samples.length);
+  for (let i = 0; i < samples.length; i++) {
+    floatData[i] = samples[i] / 32768;
+  }
+  return floatData;
+}
+
+let modelPromise;
+
+async function getModel() {
+  if (!modelPromise) {
+    const wasmDir = path.resolve(projectRoot, 'node_modules/onnxruntime-web/dist');
+    const wasmDirUrl = pathToFileURL(wasmDir).href;
+    const wasmUrl = wasmDirUrl.endsWith('/') ? wasmDirUrl : `${wasmDirUrl}/`;
+
+    const localRepo = process.env.PARAKEET_LOCAL_MODEL_DIR;
+    let modelConfig;
+
+    if (localRepo) {
+      const base = path.resolve(projectRoot, localRepo);
+      async function ensure(name) {
+        const filePath = path.join(base, name);
+        try {
+          await fs.access(filePath);
+          return filePath;
+        } catch (err) {
+          if (err.code === 'ENOENT') return null;
+          throw err;
+        }
+      }
+
+      const encoderPath = await ensure('encoder-model.onnx');
+      const encoderDataPath = await ensure('encoder-model.onnx.data');
+      const decoderPath = await ensure('decoder_joint-model.onnx');
+      const vocabPath = await ensure('vocab.txt');
+      const preprocPath = await ensure('nemo128.onnx');
+
+      modelConfig = {
+        urls: {
+          encoderUrl: encoderPath,
+          encoderDataUrl: encoderDataPath,
+          decoderUrl: decoderPath,
+          tokenizerUrl: vocabPath ? pathToFileURL(vocabPath).href : null,
+          preprocessorUrl: preprocPath,
+        },
+        filenames: {
+          encoder: 'encoder-model.onnx',
+          decoder: 'decoder_joint-model.onnx',
+        },
+      };
+
+      if (!encoderPath || !decoderPath || !vocabPath || !preprocPath) {
+        throw new Error(`PARAKEET_LOCAL_MODEL_DIR is missing required files in ${base}`);
+      }
+    } else {
+      modelConfig = await getParakeetModel('jarrelscy/parakeet-tdt-0.6b-v2-onnx', {
+        backend: 'wasm',
+        encoderQuant: 'fp32',
+        decoderQuant: 'fp32',
+      });
+    }
+
+    modelPromise = ParakeetModel.fromUrls({
+      ...modelConfig.urls,
+      filenames: modelConfig.filenames,
+      backend: 'wasm',
+      wasmPaths: wasmUrl,
+      decoderQuant: 'fp32',
+      encoderQuant: 'fp32',
+    });
+  }
+  return modelPromise;
+}
+
+async function collectAudioPairs() {
+  const files = await fs.readdir(audioDir);
+  const wavFiles = files.filter((f) => f.endsWith('.wav')).sort();
+  const pairs = [];
+  for (const wavFile of wavFiles) {
+    const base = wavFile.replace(/\.wav$/, '');
+    const txtFile = `${base}.txt`;
+    const txtPath = path.join(audioDir, txtFile);
+    try {
+      const expected = await fs.readFile(txtPath, 'utf8');
+      pairs.push({
+        name: base,
+        wavPath: path.join(audioDir, wavFile),
+        expected: expected.trim(),
+      });
+    } catch (err) {
+      const guidance = [
+        `Missing transcript file for ${wavFile}`,
+        'Run `uv run --with numpy --with onnxruntime --with huggingface-hub --with onnx-asr python scripts/generate_audiosave_transcripts.py` to refresh references.',
+      ].join('\n');
+      throw new Error(guidance);
+    }
+  }
+  return pairs;
+}
+
+test('parakeet wasm transcription matches reference texts', { timeout: 600_000 }, async (t) => {
+  let pairs;
+  try {
+    pairs = await collectAudioPairs();
+  } catch (err) {
+    throw err;
+  }
+
+  let model;
+  try {
+    model = await getModel();
+  } catch (err) {
+    if (isNetworkError(err)) {
+      t.skip('Network unavailable for HuggingFace model download');
+      return;
+    }
+    throw err;
+  }
+
+  for (const pair of pairs) {
+    await t.test(`transcribes ${pair.name}`, async () => {
+      const audio = await loadWavFloat32(pair.wavPath);
+      const result = await model.transcribe(audio, 16000, { returnTimestamps: false, returnConfidences: false });
+      const actual = result.utterance_text.trim();
+      console.log(`[${pair.name}] transcript: ${actual}`);
+      console.log(`[${pair.name}] reference: ${pair.expected}`);
+      assert.equal(actual, pair.expected);
+    });
+  }
+});

--- a/test/helpers/setup-node-env.js
+++ b/test/helpers/setup-node-env.js
@@ -1,0 +1,137 @@
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { Agent, ProxyAgent, setGlobalDispatcher } from 'undici';
+
+if (typeof process !== 'undefined' && process?.env) {
+  const proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+  if (proxyUrl) {
+    setGlobalDispatcher(new ProxyAgent(proxyUrl));
+  } else {
+    setGlobalDispatcher(new Agent());
+  }
+} else {
+  setGlobalDispatcher(new Agent());
+}
+
+const globalScope = globalThis;
+
+if (!globalScope.self) {
+  globalScope.self = globalScope;
+}
+
+if (!globalScope.window) {
+  globalScope.window = globalScope;
+}
+
+if (!globalScope.navigator) {
+  globalScope.navigator = {};
+}
+
+if (globalScope.navigator.hardwareConcurrency === undefined) {
+  globalScope.navigator.hardwareConcurrency = 4;
+}
+
+if (globalScope.navigator.userAgent === undefined) {
+  globalScope.navigator.userAgent = 'node';
+}
+
+if (globalScope.navigator.language === undefined) {
+  globalScope.navigator.language = 'en-US';
+}
+
+if (!globalScope.location) {
+  globalScope.location = new URL('https://localhost/');
+}
+
+// Force single-threaded WASM to avoid worker requirements in Node tests.
+if (typeof globalScope.SharedArrayBuffer !== 'undefined') {
+  try {
+    Object.defineProperty(globalScope, 'SharedArrayBuffer', {
+      value: undefined,
+      configurable: true,
+    });
+  } catch {
+    globalScope.SharedArrayBuffer = undefined;
+  }
+}
+
+if (!globalScope.Blob) {
+  throw new Error('Global Blob constructor not available');
+}
+
+const blobStore = new Map();
+let blobSeq = 0;
+
+URL.createObjectURL = (blob) => {
+  const id = `blob:parakeet-test-${++blobSeq}`;
+  blobStore.set(id, blob);
+  return id;
+};
+
+URL.revokeObjectURL = (url) => {
+  blobStore.delete(url);
+};
+
+const originalFsReadFile = fs.promises.readFile.bind(fs.promises);
+
+async function readBlobFile(path, options) {
+  if (typeof path === 'string' && path.startsWith('blob:parakeet-test-')) {
+    const blob = blobStore.get(path);
+    if (!blob) {
+      throw new Error(`No blob found for URL ${path}`);
+    }
+    const buffer = Buffer.from(await blob.arrayBuffer());
+    if (options && typeof options === 'object' && 'encoding' in options && options.encoding) {
+      return buffer.toString(options.encoding);
+    }
+    if (typeof options === 'string') {
+      return buffer.toString(options);
+    }
+    return buffer;
+  }
+  return null;
+}
+
+fs.promises.readFile = async (path, options) => {
+  const blobResult = await readBlobFile(path, options);
+  if (blobResult !== null) return blobResult;
+  if (typeof path === 'string' && path.startsWith('file://')) {
+    return originalFsReadFile(fileURLToPath(path), options);
+  }
+  return originalFsReadFile(path, options);
+};
+
+const originalFetch = globalScope.fetch.bind(globalScope);
+
+function isRequestLike(obj) {
+  return typeof obj === 'object' && obj !== null && typeof obj.url === 'string';
+}
+
+globalScope.fetch = async function patchedFetch(resource, init) {
+  let url = null;
+  if (typeof resource === 'string') {
+    url = resource;
+  } else if (isRequestLike(resource)) {
+    url = resource.url;
+  }
+
+  if (typeof url === 'string') {
+    if (url.startsWith('blob:parakeet-test-')) {
+      const blob = blobStore.get(url);
+      if (!blob) {
+        throw new Error(`No blob found for URL ${url}`);
+      }
+      return new Response(blob.stream(), {
+        headers: { 'content-type': blob.type || 'application/octet-stream' },
+      });
+    }
+
+    if (url.startsWith('file://')) {
+      const path = fileURLToPath(url);
+      const data = await fs.promises.readFile(path);
+      return new Response(data);
+    }
+  }
+
+  return originalFetch(resource, init);
+};

--- a/test_webgpu_fix.js
+++ b/test_webgpu_fix.js
@@ -1,5 +1,5 @@
 // Test WebGPU initialization fix
-import { initOrt } from './src/backend.js';
+import { getSelectedBackend, initOrt } from './src/backend.js';
 
 async function testWebGPU() {
   console.log('Testing WebGPU initialization...');
@@ -8,7 +8,7 @@ async function testWebGPU() {
     // Test WebGPU backend
     const ort = await initOrt({ backend: 'webgpu' });
     console.log('✅ WebGPU backend initialized successfully');
-    console.log('Backend selected:', ort._selectedBackend);
+    console.log('Backend selected:', getSelectedBackend());
     
     // Test creating a simple session to verify WebGPU works
     console.log('Testing WebGPU session creation...');


### PR DESCRIPTION
## Summary
- print the actual and reference transcripts for each audiosave wasm regression subtest
- echo the regenerated audiosave transcripts from the Python helper so CI logs show the refreshed text
- switch the audiosave transcript generator and wasm regression to use fp32 encoder/decoder weights so both sides share the same configuration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1fe0eef54832d9bd57c932f4f0fe5